### PR TITLE
fix(load): fix first load

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "jsx": "react"
+  }
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -187,7 +187,7 @@ const RootIndex = ({ data }) => {
 
         <Navigation as={Link} size={sectionNav.size} text pointing>
           <Navigation.Logo link='#top' tabIndex='0'>
-            <NavLogo fixed={sectionNav.logo?.fixed} alt='nav logo' />
+            <NavLogo fixed={sectionNav.logo?.fixed} alt='nav logo' loading='eager' fadeIn={false} />
           </Navigation.Logo>
           {sectionNav.sections.map((page, i) => (
             <Navigation.Item key={page} link={`#${page}`} tabIndex='0'>{page}</Navigation.Item>
@@ -195,7 +195,7 @@ const RootIndex = ({ data }) => {
         </Navigation>
 
         <Hero
-          logo={<GImage fixed={sectionHero?.logo?.fixed} alt='hero logo' />}
+          logo={<GImage fixed={sectionHero?.logo?.fixed} alt='hero logo' loading='eager' fadeIn={false} />}
           inlineLogo
           overlay='darker'
           baseline='bottom'
@@ -424,7 +424,8 @@ export const imageQuery = graphql`
           logo {
             title
             fixed(width: 150) {
-              ...GatsbyContentfulFixed_tracedSVG
+              # the blurry base64 version looks bad with the wordmark logo
+              ...GatsbyContentfulFixed_withWebp_noBase64
             }
           }
         }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -187,7 +187,7 @@ const RootIndex = ({ data }) => {
 
         <Navigation forwardedAs={Link} size={sectionNav.size} text pointing>
           <Navigation.Logo link='#top' tabIndex='0'>
-            <NavLogo fixed={sectionNav.logo?.fixed} alt='logo' />
+            <NavLogo fixed={sectionNav.logo?.fixed} alt='nav logo' />
           </Navigation.Logo>
           {sectionNav.sections.map((page, i) => (
             <Navigation.Item key={page} link={`#${page}`} tabIndex='0'>{page}</Navigation.Item>
@@ -195,7 +195,7 @@ const RootIndex = ({ data }) => {
         </Navigation>
 
         <Hero
-          logo={<GImage fixed={sectionHero?.logo?.fixed} alt='logo' />}
+          logo={<GImage fixed={sectionHero?.logo?.fixed} alt='hero logo' />}
           inlineLogo
           overlay='darker'
           baseline='bottom'

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -185,7 +185,7 @@ const RootIndex = ({ data }) => {
           <link rel='canonical' href='https://connectdoor.com' />
         </Helmet>
 
-        <Navigation forwardedAs={Link} size={sectionNav.size} text pointing>
+        <Navigation as={Link} size={sectionNav.size} text pointing>
           <Navigation.Logo link='#top' tabIndex='0'>
             <NavLogo fixed={sectionNav.logo?.fixed} alt='nav logo' />
           </Navigation.Logo>


### PR DESCRIPTION
- prevents the giant hero image taking over the whole screen
- adds better design to loading logos (so they don't look blurry and weird)